### PR TITLE
update get_zoom_hbox to get_menu_hbox for 4.2.X compatibility

### DIFF
--- a/addons/object_state_machine/support_editor_godot_v4/graph_state_machine.gd
+++ b/addons/object_state_machine/support_editor_godot_v4/graph_state_machine.gd
@@ -46,11 +46,11 @@ func _ready():
 	_button_new_metadata.text  = "New"
 	_button_save_metadata.text = "Save"
 
-	get_zoom_hbox().add_child(_button_first_state)
-	get_zoom_hbox().add_child(_button_normal_state)
-	get_zoom_hbox().add_child(_button_last_state)
-	get_zoom_hbox().add_child(_button_new_metadata)
-	get_zoom_hbox().add_child(_button_save_metadata)
+	get_menu_hbox().add_child(_button_first_state)
+	get_menu_hbox().add_child(_button_normal_state)
+	get_menu_hbox().add_child(_button_last_state)
+	get_menu_hbox().add_child(_button_new_metadata)
+	get_menu_hbox().add_child(_button_save_metadata)
 
 	_button_first_state.connect("button_down", _on_button_first_state)
 	_button_normal_state.connect("button_down", _on_button_normal_state)


### PR DESCRIPTION
Changed `get_zoom_hbox()` calls to `get_menu_hbox()` to make this addon work with Godot v4.2.X